### PR TITLE
security: tighten CSP, add preview headers, and add CSRF header

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,6 +7,8 @@ async function apiFetch(path: string, options?: RequestInit): Promise<Response> 
     ...options,
     headers: {
       'Content-Type': 'application/json',
+      // Forces a CORS preflight for cross-origin requests, blocking CSRF from other origins.
+      'X-Requested-With': 'XMLHttpRequest',
       ...options?.headers,
     },
   });
@@ -50,7 +52,7 @@ export async function createLabEntry(
 
 export async function deleteLabEntry(entryId: string): Promise<void> {
   try {
-    await apiFetch(`/progress/${USER_ID}/notebook/${entryId}`, {
+    await apiFetch(`/progress/${USER_ID}/notebook/${encodeURIComponent(entryId)}`, {
       method: 'DELETE',
     });
   } catch {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,35 @@ import path from 'path';
 import {defineConfig} from 'vite';
 import mkcert from 'vite-plugin-mkcert';
 
+// Dev CSP: 'unsafe-inline' on script-src is required by Vite's HMR module injection.
+// connect-src is restricted to same-origin + localhost WebSocket only (no open http:/https: wildcards).
+const DEV_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self' ws://localhost:* wss://localhost:*",
+].join('; ');
+
+// Production CSP: no inline scripts, connections restricted to same-origin only.
+const PROD_CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self'",
+].join('; ');
+
+const baseHeaders = (csp: string) => ({
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Content-Security-Policy': csp,
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+});
+
 export default defineConfig(({ command }) => ({
   plugins: [react(), tailwindcss(), ...(command === 'serve' ? [mkcert()] : [])],
   resolve: {
@@ -12,26 +41,21 @@ export default defineConfig(({ command }) => ({
     },
   },
   server: {
-    // Proxy /api requests to your upcoming Express/SQLite backend
     proxy: {
       '/api': {
-        target: 'http://localhost:3001', // Your future Express server port
+        target: 'http://localhost:3001',
         changeOrigin: true,
         secure: false,
       },
     },
-    // Dev server HMR control via environment variable
     hmr: process.env.DISABLE_HMR !== 'true',
-    headers: {
-      'X-Content-Type-Options': 'nosniff',
-      'X-Frame-Options': 'DENY',
-      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ws: wss: http: https:; report-uri /api/csp-report",
-      'Referrer-Policy': 'strict-origin-when-cross-origin',
-      'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
-    },
+    headers: baseHeaders(DEV_CSP),
+  },
+  // vite preview (npm run preview) uses production headers
+  preview: {
+    headers: baseHeaders(PROD_CSP),
   },
   build: {
-    // Prevents source maps from leaking frontend source code to the public
-    sourcemap: false, 
-  }
+    sourcemap: false,
+  },
 }));


### PR DESCRIPTION
- Split CSP into dev/prod variants: dev keeps unsafe-inline for Vite
  HMR; prod removes it from script-src entirely
- Tighten connect-src from open http:/https: wildcards to
  same-origin + localhost WebSocket only (dev) / same-origin only (prod)
- Remove dead report-uri pointing to non-existent /api/csp-report
- Add preview.headers so npm run preview also sends security headers
- Add X-Requested-With header to all API calls to force CORS preflight
  on cross-origin requests, blocking CSRF
- URL-encode entryId before interpolating into the DELETE path

https://claude.ai/code/session_01TUFwXVBPQFgSv4FCss4Bf2